### PR TITLE
Automate syncing upgrade plan with GitHub Projects

### DIFF
--- a/scripts/create-upgrade-project-items.sh
+++ b/scripts/create-upgrade-project-items.sh
@@ -1,0 +1,140 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+ISSUE_DIR="${ISSUE_DIR:-${REPO_ROOT}/upgrade-issues}"
+PROJECT_ID="${UPGRADE_PROJECT_ID:-}"
+REPO_SLUG="${GITHUB_REPO:-}"
+LABELS="${UPGRADE_ISSUE_LABELS:-upgrade}"
+DRY_RUN=0
+
+usage() {
+  cat <<'USAGE'
+Usage: create-upgrade-project-items.sh [--dry-run]
+
+Environment variables:
+  UPGRADE_PROJECT_ID   GraphQL node ID of the GitHub Project (Projects v2) to receive the issues.
+                       Obtain via `gh project view <number> --owner <org_or_user> --format json --jq '.id'`.
+  GITHUB_REPO          owner/repo slug (defaults to the current git remote origin).
+  ISSUE_DIR            Directory containing markdown files (default: upgrade-issues).
+  UPGRADE_ISSUE_LABELS Comma-separated labels to apply (default: "upgrade").
+
+Flags:
+  --dry-run            Print the actions without calling GitHub.
+
+Prerequisites: authenticated GitHub CLI (`gh`) with access to the repository and project.
+USAGE
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    --dry-run)
+      DRY_RUN=1
+      shift
+      ;;
+    *)
+      echo "Unknown argument: $1" >&2
+      usage
+      exit 1
+      ;;
+  esac
+done
+
+if [[ ! -d "$ISSUE_DIR" ]]; then
+  echo "Issue directory not found: $ISSUE_DIR" >&2
+  exit 1
+fi
+
+if [[ -z "$REPO_SLUG" ]]; then
+  if git -C "$REPO_ROOT" remote get-url origin &>/dev/null; then
+    ORIGIN_URL="$(git -C "$REPO_ROOT" remote get-url origin)"
+    REPO_SLUG="${ORIGIN_URL#*:}"
+    REPO_SLUG="${REPO_SLUG#https://github.com/}"
+    REPO_SLUG="${REPO_SLUG%.git}"
+  fi
+fi
+
+if [[ -z "$REPO_SLUG" ]]; then
+  echo "Unable to determine GITHUB_REPO. Set it explicitly." >&2
+  exit 1
+fi
+
+if ! command -v gh >/dev/null 2>&1; then
+  echo "GitHub CLI (gh) is required." >&2
+  exit 1
+fi
+
+if [[ -z "$PROJECT_ID" ]]; then
+  echo "Set UPGRADE_PROJECT_ID to the GraphQL node ID of the target GitHub Project." >&2
+  exit 1
+fi
+
+IFS=',' read -r -a LABEL_ARRAY <<< "$LABELS"
+if [[ ${#LABEL_ARRAY[@]} -eq 1 && -z "${LABEL_ARRAY[0]}" ]]; then
+  LABEL_ARRAY=()
+fi
+
+add_to_project() {
+  local issue_id="$1"
+  local issue_url="$2"
+  if (( DRY_RUN )); then
+    echo "[dry-run] Would add $issue_url to project $PROJECT_ID"
+    return
+  fi
+  if ! gh api graphql -f query='mutation($project:ID!,$content:ID!){addProjectV2ItemById(input:{projectId:$project,contentId:$content}){item{id}}}' -F project="$PROJECT_ID" -F content="$issue_id" >/dev/null 2>&1; then
+    echo "Warning: unable to add $issue_url to project $PROJECT_ID" >&2
+  else
+    echo "Added $issue_url to project"
+  fi
+}
+
+create_or_link_issue() {
+  local title="$1"
+  local body_file="$2"
+  local issue_url
+  local issue_id
+  if (( DRY_RUN )); then
+    echo "[dry-run] Would ensure issue '$title' exists using $body_file"
+    return
+  fi
+  issue_id=$(gh issue list --repo "$REPO_SLUG" --state all --search "\"$title\" in:title" --json id --jq '.[0].id' --limit 1)
+  if [[ -n "$issue_id" && "$issue_id" != "null" ]]; then
+    issue_url=$(gh issue list --repo "$REPO_SLUG" --state all --search "\"$title\" in:title" --json url --jq '.[0].url' --limit 1)
+    echo "Found existing issue for '$title': $issue_url"
+  else
+    local label_flags=""
+    if ((${#LABEL_ARRAY[@]})); then
+      printf -v label_flags ' --label %q' "${LABEL_ARRAY[@]}"
+    fi
+    local issue_json
+    issue_json=$(gh issue create --repo "$REPO_SLUG" --title "$title" --body-file "$body_file" ${label_flags} --json id,url)
+    issue_id=$(ISSUE_JSON="$issue_json" python3 - <<'PY'
+import json, os
+print(json.loads(os.environ['ISSUE_JSON']).get('id',''))
+PY
+)
+    issue_url=$(ISSUE_JSON="$issue_json" python3 - <<'PY'
+import json, os
+print(json.loads(os.environ['ISSUE_JSON']).get('url',''))
+PY
+)
+    echo "Created issue $issue_url"
+  fi
+  add_to_project "$issue_id" "$issue_url"
+}
+
+for file in "$ISSUE_DIR"/*.md; do
+  [[ -e "$file" ]] || continue
+  title=$(sed -n '1{s/^# //;p}' "$file")
+  if [[ -z "$title" ]]; then
+    echo "Skipping $file (missing '# Title' line)" >&2
+    continue
+  fi
+  echo "Processing: $title"
+  create_or_link_issue "$title" "$file"
+done

--- a/upgrade-issues/01-toolchain.md
+++ b/upgrade-issues/01-toolchain.md
@@ -1,0 +1,14 @@
+# Align toolchain, workflows, and dependencies
+
+## Summary
+Bring the Node.js toolchain, npm dependencies, and GitHub Actions workflows up to the current LTS releases so the UI matches the modernization plan and benefits from the latest security patches.
+
+## Tasks
+- [ ] Confirm the Node.js and npm versions that should be treated as the new baseline (currently Node 22 LTS) and align Docker, local dev, and CI on that toolchain.
+- [ ] Move workflows to `actions/checkout@v4`, `actions/setup-node@v4`, `docker/setup-buildx-action@v3`, `docker/login-action@v3`, and `docker/build-push-action@v6`.
+- [ ] Drop the bespoke `docker-compose` installation inside CI in favor of the built-in `docker compose` subcommand.
+- [ ] Upgrade runtime dependencies (`vue`, `vue-router`, `pinia`, `axios`, `@heroicons/vue`, `chromadb`) and remove `chromadb` plus the `optimizeDeps.exclude` entry if the package is unused.
+- [ ] Upgrade dev/build dependencies (`vite`, `@vitejs/plugin-vue`, `vue-tsc`, `@vue/tsconfig`, `typescript`, `tailwindcss`, `postcss`, `autoprefixer`, `markdownlint-cli`, `cypress`, `start-server-and-test`).
+- [ ] Add missing testing dependencies (`vitest`, `@vitest/coverage-v8`, `@vue/test-utils`, `jsdom`/`happy-dom`) and npm scripts such as `test:unit`.
+- [ ] Regenerate `package-lock.json` and run Tailwind's upgrade helper so generated config files line up with the new dependency versions.
+- [ ] Point Vite's PostCSS config at `postcss.config.cjs` (or convert the config to `.js`) so the dev server loads the right file.

--- a/upgrade-issues/02-backend.md
+++ b/upgrade-issues/02-backend.md
@@ -1,0 +1,10 @@
+# Backend connectivity & environment parity
+
+## Summary
+Respect the documented `.env` configuration, reuse a shared API client, and make sure tenant/database selections propagate to every Chroma request.
+
+## Tasks
+- [ ] Load `VITE_CHROMADB_HOST`, protocol, and related values from `.env` when initializing the auth store and login form instead of hard-coding `localhost:8000` and `http`.
+- [ ] Replace the `DEFAULT_PARAMS` constant in `src/stores/chroma.ts` with getters that read the selected tenant and database from the auth store so every request honors the active session.
+- [ ] Create a shared Axios instance (or helper) for the base URL and headers, and migrate all request helpers—including login—to that implementation.
+- [ ] Ensure the login heartbeat logic uses the same helper instead of duplicating a standalone `fetch` call.

--- a/upgrade-issues/03-collections-ux.md
+++ b/upgrade-issues/03-collections-ux.md
@@ -1,0 +1,11 @@
+# Collections screen correctness and UX polish
+
+## Summary
+Finish the UX polish items promised in the README by ensuring alphabetical ordering, proper component registration, and accessibility enhancements.
+
+## Tasks
+- [ ] Sort `chromaStore.collections` before pagination so the table always appears alphabetical regardless of insertion order.
+- [ ] Import and register `<LoadingSkeleton>` inside `DocumentsList.vue` so stricter tooling builds cleanly.
+- [ ] Register the `focus-trap` directive globally in `main.ts` so `<AddDocumentModal>` traps focus as designed.
+- [ ] Remove or fix the stale `<link href="/src/styles.css">` entry in `index.html` since `src/style.css` is already included via `main.ts`.
+- [ ] Prefill the login tenant/database inputs with the last authenticated values to meet the UX spec.

--- a/upgrade-issues/04-security-session.md
+++ b/upgrade-issues/04-security-session.md
@@ -1,0 +1,10 @@
+# Security, persistence, and session recovery
+
+## Summary
+Implement the encrypted storage, automatic expiration, and session recovery behaviors promised in the specification so auth state is resilient and secure.
+
+## Tasks
+- [ ] Encrypt the auth payload written to `localStorage` (e.g., via Web Crypto AES-GCM) and attach an expiration timestamp per the spec.
+- [ ] Clear stale credentials automatically when the app boots so expired sessions never silently persist.
+- [ ] Store the last visited route and restore it on refresh while ensuring router guards respect session recovery requirements.
+- [ ] Surface backend errors through the shared notification system instead of inline strings on the login form.

--- a/upgrade-issues/05-testing-qa.md
+++ b/upgrade-issues/05-testing-qa.md
@@ -1,0 +1,11 @@
+# Testing & QA modernization
+
+## Summary
+Adopt Vitest-based unit tests, modernize Cypress, and ensure CI runs lint/unit/e2e checks so regressions are caught automatically.
+
+## Tasks
+- [ ] Add Vitest, Vue Test Utils, and DOM environment dependencies plus `npm run test:unit`, and scaffold representative unit tests under `tests/unit`.
+- [ ] Update `.github/workflows/build.yml` to run linting, unit tests, and Cypress e2e suites (potentially via `start-server-and-test`).
+- [ ] Upgrade Cypress configuration to the format supported by the current release, set the correct base URL, and refresh fixtures/endpoints to match the upgraded stores.
+- [ ] Modernize Cypress custom commands to avoid brittle regex URL rewrites and share fixtures between auth flows.
+- [ ] Cache Cypress binaries in CI for faster runs.

--- a/upgrade-issues/06-docs-release.md
+++ b/upgrade-issues/06-docs-release.md
@@ -1,0 +1,10 @@
+# Documentation & release updates
+
+## Summary
+Keep the README, tech context, and release docs accurate after the upgrade so onboarding instructions match the new stack.
+
+## Tasks
+- [ ] Update the README Quick Start port reference (Vite defaults to 5173) or change Vite’s dev server port to match the docs.
+- [ ] Document the environment variables (host, protocol, tenant/database defaults) that the UI now respects.
+- [ ] Refresh `memory-bank/techContext.md` (and CONTRIBUTING if needed) with the new testing layout and tooling.
+- [ ] Describe the new workflows/tooling that contributors need to run (Vitest, updated CI jobs, etc.).

--- a/upgrade-issues/07-docker-release.md
+++ b/upgrade-issues/07-docker-release.md
@@ -1,0 +1,10 @@
+# Docker, backend image, and release automation
+
+## Summary
+Update the Docker Compose stack and release workflow so the app targets the latest Chroma server image and produces signed, semantically versioned artifacts.
+
+## Tasks
+- [ ] Point `docker/docker-compose.yaml` at the latest `ghcr.io/chroma-core/chroma` image and capture any new env vars required for multi-auth setups.
+- [ ] Verify that the multi-auth configuration (ports 8001–8003) keeps working after the backend upgrade.
+- [ ] Ensure the release workflow tags Docker images with semantic versions and, if required, attaches SBOM/signing steps.
+- [ ] Align the release workflow's GitHub Action versions with the upgraded build workflow so both stay supported.

--- a/upgrade.md
+++ b/upgrade.md
@@ -1,0 +1,65 @@
+# Upgrade project tracker
+
+Each section below is formatted as a GitHub issue that can be copied directly into the repository tracker. The checklist items in every issue describe the concrete work required to bring this UI up to the current specification described in the provided upgrade plan.
+
+## GitHub project automation
+
+To seed (or re-sync) a GitHub Project with these issues:
+
+1. Review the markdown files in `upgrade-issues/`—each file mirrors one of the sections below and is used as the body when creating the issue.
+2. Run `scripts/create-upgrade-project-items.sh` with the following environment variables set:
+   - `UPGRADE_PROJECT_ID`: GraphQL node ID for the destination Project (Projects v2). Fetch with `gh project view <number> --owner <org_or_user> --format json --jq '.id'`.
+   - `GITHUB_REPO`: optional `owner/repo` override (defaults to the current git remote).
+   - `UPGRADE_ISSUE_LABELS`: optional comma-separated labels (defaults to `upgrade`).
+3. The script idempotently creates any missing issues, applies the requested labels, and adds every issue to the specified Project. Pass `--dry-run` to preview the operations without calling GitHub.
+
+This keeps the markdown tracker as the source of truth while ensuring the GitHub Project stays synchronized.
+
+## Issue: Align toolchain, workflows, and dependencies
+- [ ] Confirm the latest LTS release of Node.js (currently 22.x) and npm, and standardize Docker, local dev, and CI on that version.
+- [ ] Update GitHub Actions to `actions/checkout@v4`, `actions/setup-node@v4`, `docker/setup-buildx-action@v3`, `docker/login-action@v3`, and `docker/build-push-action@v6`.
+- [ ] Remove the bespoke `docker-compose` installation step in workflows in favor of the built-in `docker compose` subcommand.
+- [ ] Upgrade runtime deps (`vue`, `vue-router`, `pinia`, `axios`, `@heroicons/vue`, `chromadb`) and remove `chromadb` plus the related `optimizeDeps.exclude` entry if it remains unused after auditing the codebase.
+- [ ] Upgrade dev/build deps (`vite`, `@vitejs/plugin-vue`, `vue-tsc`, `@vue/tsconfig`, `typescript`, `tailwindcss`, `postcss`, `autoprefixer`, `markdownlint-cli`, `cypress`, `start-server-and-test`).
+- [ ] Add testing deps (`vitest`, `@vitest/coverage-v8`, `@vue/test-utils`, `jsdom` or `happy-dom`) and npm scripts such as `test:unit`.
+- [ ] Regenerate `package-lock.json` and re-run Tailwind’s upgrade helper to ensure config files align with the new versions.
+- [ ] Point Vite’s PostCSS config to the actual file (`postcss.config.cjs`) or convert it to `.js` so the dev server picks it up correctly.
+
+## Issue: Backend connectivity & environment parity
+- [ ] Respect `VITE_CHROMADB_HOST`, protocol, and related `.env` values when initializing the login form and auth store instead of hard-coding `localhost:8000` and `http`.
+- [ ] Wire tenant and database defaults from the auth store into every request by replacing the `DEFAULT_PARAMS` constant inside `src/stores/chroma.ts` with getters that pull the live values.
+- [ ] Centralize Axios base URL and shared headers in a helper/instance so every API call (including login) uses identical request construction.
+- [ ] Update `LoginScreen` to rely on the same helper instead of duplicating a manual `fetch` call.
+
+## Issue: Collections screen correctness and UX polish
+- [ ] Sort `chromaStore.collections` before pagination so the list always appears alphabetized as promised in the README.
+- [ ] Import and register the loading skeleton component inside `DocumentsList.vue` so stricter tooling doesn’t fail at build time.
+- [ ] Register the `focus-trap` directive globally in `main.ts` so `<AddDocumentModal>` gains the expected accessibility behavior.
+- [ ] Remove or fix the broken `<link href="/src/styles.css">` tag in `index.html` (Vite already includes `src/style.css`).
+- [ ] Prefill login tenant/database fields from the last authenticated session to meet the UX spec.
+
+## Issue: Security, persistence, and session recovery
+- [ ] Encrypt the auth payload stored in `localStorage` (e.g., via Web Crypto AES-GCM) and attach an expiration timestamp per spec.
+- [ ] Clear stale credentials automatically during app bootstrap to avoid reusing expired data.
+- [ ] Capture the user’s last route and restore it on refresh while ensuring router guards honor session recovery requirements.
+- [ ] Surface backend errors through the shared notification system rather than inline strings on the login page.
+
+## Issue: Testing & QA modernization
+- [ ] After adding Vitest, scaffold unit tests for key components/stores in `tests/unit` and add `npm run test:unit`.
+- [ ] Extend `.github/workflows/build.yml` to run linting, unit tests, and Cypress e2e tests (potentially via `start-server-and-test`).
+- [ ] Upgrade Cypress config to the latest format, ensure the base URL matches Vite’s dev server, and refresh fixtures to call the correct HTTP endpoints.
+- [ ] Modernize Cypress custom commands to avoid brittle regex URL rewrites and share fixtures across auth flows.
+- [ ] Cache Cypress binaries in CI for faster runs.
+
+## Issue: Documentation & release updates
+- [ ] Update README quick-start instructions to reference the correct Vite port (`5173`) or change Vite’s config to match the documented port.
+- [ ] Document the newly respected environment variables (host, protocol, tenant/database defaults) and describe how to configure them.
+- [ ] Refresh `memory-bank/techContext.md` with the final testing layout after the Vitest + Cypress updates.
+- [ ] Describe any new tooling requirements (Vitest, updated workflows) in CONTRIBUTING docs if applicable.
+
+## Issue: Docker, backend image, and release automation
+- [ ] Update `docker/docker-compose.yaml` to pull the latest `ghcr.io/chroma-core/chroma` image and note any new env vars required for multi-auth setups.
+- [ ] Validate that the multi-auth configuration (ports 8001–8003) continues to work after upgrading the server image.
+- [ ] Ensure the release workflow tags Docker images with semantic versions and, if required, add SBOM/signing steps.
+- [ ] Align the release workflow versions with the build workflow updates noted above so Actions stay on supported releases.
+


### PR DESCRIPTION
## Summary
- add detailed markdown files for each upgrade issue so they can be used as GitHub issue bodies
- document how to sync those issues into a GitHub Project via a new automation script referenced from `upgrade.md`
- provide `scripts/create-upgrade-project-items.sh` to create/label issues (or re-use existing ones) and add them to the specified Project

## Testing
- Not run (not requested)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69196161c5f883299e9349f55907d3af)